### PR TITLE
Add forceReload to reload all imported modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ directoryImport('./sample-directory', (moduleName, modulePath, moduleData) => {
 | importPattern         | RegExp  | RegExp pattern to filter files                                  |
 | importMode            | String  | The import mode. Can be 'sync' or 'async'                       |
 | limit                 | Number  | Limit the number of imported modules                            |
+| forceReload           | Boolean | If true, reload modules disabling require cache                 |
 
 [back to top](#top)
 
@@ -334,6 +335,11 @@ directoryImport(options, (moduleName, modulePath, moduleData) => {
 ---
 
 ## Change Log
+
+### [3.3.2] - 2024-12-25
+
+#### Added
+- Add forceReload option.
 
 ### [3.3.1] - 2024-03-27
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "directory-import",
-  "version": "3.2.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "directory-import",
-      "version": "3.2.1",
+      "version": "3.3.2",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.8",
@@ -29,7 +29,6 @@
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-sonarjs": "^0.23.0",
         "eslint-plugin-unicorn": "^49.0.0",
-        "husky": "^8.0.3",
         "jest": "^29.7.0",
         "prettier": "^3.1.0",
         "ts-jest": "^29.1.1",
@@ -5836,21 +5835,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directory-import",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Module will allow you to synchronously or asynchronously import (requires) all modules from the folder you specify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "rimraf ./dist && tsup",
     "start": "node dist/index.js",
-    "publish": "npm run build && npm publish",
+    "prepare": "npm run build",
+    "publish": "npm run prepare && npm publish",
     "jest": "jest --silent test/index.test.ts",
     "jest:watcher": "jest --watchAll",
     "jest:windows": "jest --silent test-windows/index.test.ts"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-sonarjs": "^0.23.0",
     "eslint-plugin-unicorn": "^49.0.0",
-    "husky": "^8.0.3",
     "jest": "^29.7.0",
     "prettier": "^3.1.0",
     "ts-jest": "^29.1.1",

--- a/src/import-modules.ts
+++ b/src/import-modules.ts
@@ -77,6 +77,11 @@ function importModule(
 
   const relativeModulePath = filePath.slice(options.targetDirectoryPath.length);
 
+  if (options.forceReload) {
+    // eslint-disable-next-line security/detect-non-literal-require, @typescript-eslint/no-var-requires, unicorn/prefer-module
+    delete require.cache[filePath];
+  }
+
   // eslint-disable-next-line security/detect-non-literal-require, @typescript-eslint/no-var-requires, unicorn/prefer-module
   const importedModule = require(filePath) as unknown;
 

--- a/src/prepare-private-options.ts
+++ b/src/prepare-private-options.ts
@@ -16,6 +16,7 @@ const getDefaultOptions = (): ImportedModulesPrivateOptions => {
     callerFilePath: path.resolve('/'),
     callerDirectoryPath: path.resolve('/'),
     targetDirectoryPath: path.resolve('/'),
+    forceReload: false,
   };
 
   options.callerFilePath =

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -22,6 +22,7 @@ export interface ImportedModulesPublicOptions {
   importPattern?: RegExp;
   importMode?: ImportModulesMode;
   limit?: number;
+  forceReload?: boolean;
 }
 
 export interface ImportedModulesPrivateOptions extends Required<ImportedModulesPublicOptions> {


### PR DESCRIPTION
If directoryImport is called more than once, all modules loaded in the previous call are imported via require.cache so if module is changed on filesystem these changes are missing. 

This option force module to be loaded from scratch deleting caching version.